### PR TITLE
Some tests for base64 and if I understand correctly a partial fix

### DIFF
--- a/examples/base64.c
+++ b/examples/base64.c
@@ -29,6 +29,35 @@ void init_parser(void)
 }
 
 
+#include <string.h>
+#include <assert.h>
+#define TRUE (1)
+#define FALSE (0)
+
+void assert_parse(int expected, char *data) {
+    const HParseResult *result;
+
+    size_t datasize = strlen(data);
+    result = h_parse(document, (void*)data, datasize);
+    if((result != NULL) != expected) {
+        printf("Test failed: %s\n", data);
+    }
+}
+
+void test() {
+    assert_parse(TRUE, "");
+    assert_parse(TRUE, "YQ==");
+    assert_parse(TRUE, "YXU=");
+    assert_parse(TRUE, "YXVy");
+    assert_parse(TRUE, "QVVSIFNBUkFG");
+    assert_parse(TRUE, "QVVSIEhFUlUgU0FSQUY=");
+    assert_parse(FALSE, "A");
+    assert_parse(FALSE, "A=");
+    assert_parse(FALSE, "A==");
+    assert_parse(FALSE, "AAA==");
+}
+
+
 #include <stdio.h>
 
 int main(int argc, char **argv)
@@ -38,6 +67,8 @@ int main(int argc, char **argv)
     const HParseResult *result;
 
     init_parser();
+
+    test();
 
     inputsize = fread(input, 1, sizeof(input), stdin);
     fprintf(stderr, "inputsize=%lu\ninput=", inputsize);


### PR DESCRIPTION
I tried running `echo STUFF | base64 -w 0 | ./base64`, but it almost always failed to parse.

So I wrote a test() function that gets called at the beginning of base64:main() and only outputs things if tests fail. Some tests do (as I expected, seeing the comment about "why doesn't it behave like we expect?!").

I think I also improved the parser itself in the second commit, but I did base64 from memory and hammer from grep, so I probably just broke things.

This looks fun, I might hack on it a bit more if I can get some showing-around.
