### PR TITLE
docs: fix simple typo, occurances -> occurrences

### DIFF
--- a/src/backends/llk.c
+++ b/src/backends/llk.c
@@ -230,7 +230,7 @@ int h_llk_compile(HAllocator* mm__, HParser* parser, const void* params)
 
   // TODO: eliminate common prefixes
   // TODO: eliminate left recursion
-  // TODO: avoid conflicts by splitting occurances?
+  // TODO: avoid conflicts by splitting occurrences?
 
   // generate table and store in parser->backend_data.
   HLLkTable *table = h_llktable_new(mm__);

--- a/src/cfgrammar.c
+++ b/src/cfgrammar.c
@@ -297,7 +297,7 @@ HStringMap *h_stringmap_copy(HArena *a, const HStringMap *m)
   return res;
 }
 
-/* Replace all occurances of old in m with new.
+/* Replace all occurrences of old in m with new.
  * If old is NULL, replace all values in m with new.
  * If new is NULL, remove the respective values.
  */
@@ -554,7 +554,7 @@ const HStringMap *h_follow_(size_t k, HCFGrammar *g, HCFChoice **s)
 
 const HStringMap *h_follow(size_t k, HCFGrammar *g, const HCFChoice *x)
 {
-  // consider all occurances of X in g
+  // consider all occurrences of X in g
   // the follow set of X is the union of:
   //   {$} if X is the start symbol
   //   given a production "A -> alpha X tail":


### PR DESCRIPTION
There is a small typo in src/backends/llk.c, src/cfgrammar.c.

Should read `occurrences` rather than `occurances`.

